### PR TITLE
Updated pull request: sorting shell script

### DIFF
--- a/3.5-sort_fasta.sh
+++ b/3.5-sort_fasta.sh
@@ -3,4 +3,4 @@
 
 infile=$1
 outfile=$1.sorted.fasta
-gawk -e '/#/ {sub(/lcl\|/,""); print $1 "," $2 $3 }' RS=">" $infile | sort | gawk -e '/#/ {print ">" $1 "\n" $2}' FS="," > $outfile
+gawk -e '{sub(/lcl\|/,""); print $1 "," $2 $3 }' RS=">" $infile | sort | gawk -e '{print ">" $1 "\n" $2}' FS="," > $outfile


### PR DESCRIPTION
Shell script to sort a fasta file, required for many steps in the pipeline.

I wrote a one-liner similar to the one you found earlier that will take the fasta file you generate after finding the paired end and sort it into alternating pairs. I wrapped it in as a shell script but obviously you could pull out the line and use it anywhere you want.
