### PR TITLE
Sort contigs

### DIFF
--- a/sTRAM.pl
+++ b/sTRAM.pl
@@ -432,7 +432,7 @@ close COMPLETE_FH;
 
 my @best_unsorted = ();
 foreach my $contig_name (keys $hit_matrix) {
-	if ($hit_matrix->{$contig_name}->{"total"} > ($best_score / 2)) {
+	if ($hit_matrix->{$contig_name}->{"total"} > ($best_score - 100)) {
 		push @best_unsorted, $contig_name;
 	}
 }


### PR DESCRIPTION
Sorts contigs returned in .best.fasta, with highest blast score first (and secondarily sorted by longest sequence, if scores are equal).

Also increased stringency of best contigs: now returns any contigs within 100 of the highest-scoring contig.
