### PR TITLE
Do a case-insensitive search for the lib directory path

### DIFF
--- a/lib/Configuration.pm
+++ b/lib/Configuration.pm
@@ -38,7 +38,7 @@ sub initialize {
 		$path = realpath ($path);
 		$path = File::Spec->canonpath($path);
 		$path =~ s/\\/\//g;
-		if ($path =~ /TRAM.*lib/) {
+		if ($path =~ /TRAM.*lib/i) {
 			$config_file = File::Spec->catfile($path, "config.txt");
 			$assembler_dir = File::Spec->catdir($path, "Assembler");
 			last;


### PR DESCRIPTION
Assembler module search fails if the installation directory has been renamed from aTRAM. This is a simple quick fix.
