### PR TITLE
Trinity iteration problem

### DIFF
--- a/lib/Assembler/Trinity.pm
+++ b/lib/Assembler/Trinity.pm
@@ -46,6 +46,8 @@ sub assembler {
 	run_command (get_bin($binaries->{trinity}), "--seqType fa --single $short_read_file --run_as_paired --JM $jm --output $tempdir");
 
 	my ($contigs, undef) = parsefasta ("$tempdir/Trinity.fasta");
+	#### removing the trinity folder so trinity will now do more than one iteration
+	`rm -r $tempdir/`;
 
 	open OUTFH, ">", $output_file;
 	foreach my $contigname (keys %$contigs) {


### PR DESCRIPTION
Added a line of code to remove the Trinity directory, so it will now run more than one iteration. Trinity was quitting at iteration 2 every time, because the previous assembly was still present in the folder. This line fixes that. Tested with and without -tempdir flag.