### PR TITLE
Two fixes with format_sra

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,20 +1,21 @@
-#     Manual for aTRAM
+#Using aTRAM
 
 Here are the required commands for running aTRAM as well as a few things to keep in mind for maximum efficiency. Required commands are indicated and optional commands are in brackets. 
 
 
-## Setup:
+## Setup
 To determine if aTRAM can run on your computer:
 
 ### configure.pl
 
-######perl configure.pl 
-  
-  This script will determine if BLAST, muscle, mafft and other de novo assembly software are available. It will create a text file called configure.txt in the lib folder with the paths to the programs. They can be available in your $PATH by adding them directly to the appropriate folder (e.g. /usr/bin) or add the path to the programs to your $PATH. Alternatively, the configure.txt file can be edited directly with the path to the programs after configure.pl is run. BLAST is required and at least one of the de novo assemblers are required Trinity or Velvet.
-  
+```perl configure.pl```
+ 
+This script will determine if BLAST, muscle, mafft and other de novo assembly software are available. It will create a text file called configure.txt in the lib folder with the paths to the programs. They can be available in your $PATH by adding them directly to the appropriate folder (e.g. /usr/bin) or add the path to the programs to your $PATH. Alternatively, the configure.txt file can be edited directly with the path to the programs after configure.pl is run. BLAST is required and at least one of the de novo assemblers,  Trinity or Velvet, are required.
+ 
 If you have problems running configure.pl for the first time, delete lib/config.txt.
 
 URLs for software:
+
 * BLAST: http://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs&DOC_TYPE=Download
 * Velvet: https://www.ebi.ac.uk/~zerbino/velvet/
 * Trinity: http://trinityrnaseq.sourceforge.net
@@ -25,71 +26,103 @@ URLs for software:
 
 ### format_SRA.pl
 
-######perl format_SRA.pl -input inputfile.fastq [-output Database Name | -number Number of Shards ]
+```perl format_SRA.pl -input inputfile.fastq [-output Database Name | -number Number of Shards ]```
 
-This script will create an aTRAM blast formatted database of your Illumina run. By default it will split the short read archive into shards for every 250 MB. The final aTRAM database will have roughly (Number of GB of a fasta file)/4 blast formatted databases. You can specify a database name with -output and the number of shards with -number.  We calculated 250 MB based on the memory allocated to BLAST and time necessary to search through each database. 
-  
-The -input file can be either fastq or fasta, the two paired end reads should be in one file. Concatenate the two files together if necessary.
+This script will create an aTRAM-formatted database of your Illumina run. By default, it will split the short read archive into ~250 MB shards. The final aTRAM database will have roughly (number of GB of a fasta file)/4 shards. We chose 250 MB based on the memory allocated to BLAST and time necessary to search through each database. You can specify the number of shards created with `-number`.
 
+`-output` specifies the name of the aTRAM database. 
+ 
+`-input` specifies the fastq or fasta file of short reads. Concatenate the two files together if necessary.
 
 ### aTRAM.pl
 
-######perl  aTRAM.pl -sra DatabaseName -target TargetSequence.fasta  [-fraction Fraction | -complete | -protein | -max_processes | -max_memory | -shards number | -log_file filename | -help | -output_file filename | -temp_name | -save_temp ]
+```perl aTRAM.pl -sra DatabaseName -target TargetSequence.fasta [-fraction Fraction | -complete | -protein | -max_processes | -max_memory | -shards number | -log_file filename | -help | -output_file filename | -temp_name | -save_temp ]```
 
 Required Parameters:
-  * - sra DatabaseName, the name of the formatted short read archive from format_sra.pl
-  * - target  TargetSequence.fasta, the target gene in either DNA or Amino Acid format, if AA turn on -protein
+ 
+ * `-sra DatabaseName`: the name of the formatted short read archive from format_sra.pl
+ * `-target TargetSequence.fasta`: the target gene in either DNA or Amino Acid format. (if AA, use the `-protein` flag)
 
 Important Optional Parameters:
-  * - complete  [on/off], will autocomplete if the atram output blasts back to both the beginning and end of the target sequence, indicates the full target has been recovered.
-  * - fraction number bewteen 0-1,  fraction of the full Illumina database to search, a good starting point would be to aim for 20X coverage
-  * - protein  [on/off], turns on if the target sequence is in Amino Acids
-  
+
+ * `-complete` [on/off]: if the atram output blasts back to both the beginning and end of the target sequence, indicates the full target has been recovered.
+ * `-fraction [number between 0-1]`: fraction of the full Illumina database to search, a good starting point would be to aim for 20X coverage
+ * -protein [on/off], turns on if the target sequence is in Amino Acids
+ 
 Other Optional Parameters:
-  * - help will give program parameters
-  * - log_file  filename,    will create one file for all the log output
-  * - output_file filename,  will create the output file
-  * - shards number,  number of shards to search
-  * - temp_name filename, names a temporary file to store XXXX
-  * - save_temp filename, saves the temp file
+
+ * `-help` will give program parameters
+ * `-log_file filename` will create one file for all the log output
+ * `-output_file filename` specifies the output file prefix
+ * `-shards number` specifies the number of shards to search
+ * `-temp_name filename` names a temporary file to store XXXX
+ * `-save_temp filename` saves the temp file
 
 Running on a Cluster:
-  * - max_processes  maximum  number of processes to run for each search
-  * - max_memory maximum amount of memory to allocate to aTRAM
 
+ * `-max_processes number`: maximum number of processes to run for each search
+ * `-max_memory number`: maximum amount of memory to allocate to aTRAM
 
-Parameters with modifiable default values:    
-  * -ins_length number
-  * -iterations number, number of iterations before the program stops, default 5
-  * -start_iter number, iteration to start on if continuing running aTRAM from a previous run
-  * -exp_coverage number, the expected coverage of the region for velvetg (default 30).
-  * -evalue  number, can allow for different e-values in blast search
-  * -max_target_seqs, maxumum number of hits BLAST will identify
-  * -assembler,  by default this is Velvet but it can be set to run Trinity -assembler = "Trinity"
-  * -kmer, kmer number for assemblers
+Parameters with modifiable default values: 
+
+ * `-ins_length number`: the average insert length of the Illumina library
+ * `-iterations number`: the number of iterations before the program stops ( default 5)
+ * `-start_iter number`: the iteration to start on if restarting aTRAM from a previous run
+ * `-exp_coverage number`: expected coverage of the region for velvetg (default 30).
+ * `-evalue number`: e-value for blast search
+ * `-max_target_seqs`: maximum number of hits BLAST will identify
+ * `-assembler assemblername`: specifies one of the configured de novo assemblers in lib/Assemblers (default Velvet)
+ * `-kmer number`: kmer number to pass to the assembler
 
 
 ## Pipelines
 
-#### BasicPipeline.pl
-Runs aTRAM on a list of genes on a number of aTRAM formatted databases.
+### BasicPipeline.pl
+Runs aTRAM for a number of target sequences on a number of aTRAM databases.
 
-######perl BasicPipeline.pl -samples SampleFile.txt -targets -TargetFile.txt [atram parameters -complete -protein]
-##### TargetFile.txt  tab delimited file 
-genename  path/gene.fasta
+```perl BasicPipeline.pl -samples SampleFile.txt -targets -TargetFile.txt [atram parameters -complete -protein]```
 
-##### SampleFile.txt  tab delimited file, will create a directory for each sample  
-SampleName  path/atram_db
+* `TargetFile.txt`: tab-delimited file; each line contains the target name and the path to its fasta file
+* `SampleFile.txt`: tab-delimited file; each line contains the sample name and the path to its aTRAM-formatted database
 
+#### Results:
 
-#### AlignmentPipeline.pl 
-aTRAM on a list of genes on a number of aTRAM formatted databases then aligns the aTRAM contigs back to the target
+`pipeline.log` contains the entire console output of the pipeline.
 
-######perl AlignmentPipeline.pl -samples SampleFile.txt -targets -TargetFile.txt [atram parameters -complete -protein]
-##### TargetFile.txt  tab delimited file 
-genename  path/gene.fasta
+For each sample, there is a directory of results. Each of those directories contains the following:
 
-##### SampleFile.txt  tab delimited file, will create a directory for each sample  
-SampleName  path/atram_db
+* `.all.fasta` has all of the contigs pulled out in each iteration
+* `.best.fasta` has the best contigs for each iteration
+* `.results.txt` is the aTRAM results file for this sample.
+
+### AlignmentPipeline.pl 
+Runs aTRAM for a number of target sequences on a number of aTRAM databases, then aligns the resulting contigs back to the target sequences. Target sequences must be DNA, not amino acid.
+
+```perl AlignmentPipeline.pl -samples SampleFile.txt -targets -TargetFile.txt [atram parameters -complete -protein]```
+
+* `TargetFile.txt`: tab-delimited file; each line contains the target name and the path to its fasta file
+* `SampleFile.txt`: tab-delimited file; each line contains the sample name and the path to its aTRAM-formatted database
+
+#### Results:
+
+For each target sequence, there is a directory of results. Each of those directories contains the following:
+
+`results.txt` contains the overall summary of the pipeline results in tabular form: each sample's best contig is listed, with summary statistics for its bitscore and percent coverage of the target sequence.
+
+`pipeline.log` contains the entire console output of the pipeline.
+
+The `aTRAM` directory contains the per-sample results. For each sample, there are six files: 
+
+* `.all.fasta` has all of the contigs pulled out in each iteration
+* `.best.fasta` has the best contigs for each iteration
+* `.complete.fasta` has the contigs that cover both ends of the target sequence
+* `.align.fasta` uses MUSCLE to align the contigs from .best.fasta to the target sequence
+* `.trimmed.fasta` takes the MUSCLE alignment and trims out any gaps relative to the target sequence.
+* `.results.txt` is the aTRAM results file for this sample.
+
+The `alignments` folder contains summary results over all samples. There are two fasta files:
+
+* `.full.fasta` contains the entire sequence of the best-scoring contig for every sample, including introns and assemblies that go beyond the ends of the target sequence.
+* `.trimmed.fasta` contains those same contigs aligned to the target sequence and trimmed of gaps relative to the target sequence. If the target sequence was a CDS, this file will not contain introns.
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ doi:10.5281/zenodo.10431
 aTRAM performs targeted de novo assembly of loci from paired-end Illumina runs. 
 
 When using this software please cite:
-Allen, JM, DI Huang, QC Cronk, KP Johnson. 2015. aTRAM automated target restricted assembly method a fast method for assembling loci across divergent taxa from next-generation sequencing data. BMC Bioinformatics 16:98 DOI 10.1186/s12859-015-0515-2
+```Allen, JM, DI Huang, QC Cronk, KP Johnson. 2015. aTRAM automated target restricted assembly method a fast method for assembling loci across divergent taxa from next-generation sequencing data. BMC Bioinformatics 16:98 DOI 10.1186/s12859-015-0515-2```
 
 ###Installation###
 aTRAM can be run directly from the downloaded Github repo. To make sure you have all the software required by aTRAM, we provide ```configure.pl``` to check for dependencies.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ doi:10.5281/zenodo.10431
 aTRAM performs targeted de novo assembly of loci from paired-end Illumina runs. 
 
 When using this software please cite:
+
 ```Allen, JM, DI Huang, QC Cronk, KP Johnson. 2015. aTRAM automated target restricted assembly method a fast method for assembling loci across divergent taxa from next-generation sequencing data. BMC Bioinformatics 16:98 DOI 10.1186/s12859-015-0515-2```
 
 ###Installation###

--- a/format_sra.pl
+++ b/format_sra.pl
@@ -328,13 +328,14 @@ format_sra.pl
 
 =head1 SYNOPSIS
 
-format_sra.pl -input short_read_archive [-output aTRAM_db_name] [-number int]
+format_sra.pl [-input short_read_archive | -1input sra1 -2input sra2] [-output aTRAM_db_name] [-number int]
 
 Takes a fasta or fastq file of paired-end short reads and creates an aTRAM database for use by aTRAM.pl.
 
 =head1 OPTIONS
 
- -input:   short read archive.
+ -input:   short read archive in fasta or fastq format. Use this option if both ends are in a single file.
+ -1input, -2input: short read archives for 1st and 2nd paired-end reads, in fasta or fastq format.
  -output:  optional: prefix of aTRAM database (default is the same as -input).
  -number:  optional: number of shards to create (default is however many are required for each to be ~250MB).
 

--- a/format_sra.pl
+++ b/format_sra.pl
@@ -18,6 +18,8 @@ if (@ARGV == 0) {
 my $runline = "Running " . basename($0) . " " . join (" ", @ARGV) . ", " . get_version() . "\n";
 
 my $short_read_archive = "";
+my $short_read_1 = "";
+my $short_read_2 = "";
 my $output_file = "";
 my $log_file = "";
 my $help = 0;
@@ -26,6 +28,8 @@ my $numshards = 0;
 my $max_processes = 4;
 
 GetOptions ('input=s' => \$short_read_archive,
+			'1input=s' => \$short_read_1,
+			'2input=s' => \$short_read_2,
             'output=s' => \$output_file,
             'number=i' => \$numshards,
             'debug' => \$debug,
@@ -37,8 +41,38 @@ if ($help) {
     pod2usage(-verbose => 1);
 }
 
+if ($log_file eq "") {
+	$log_file = "$output_file.log";
+}
+
+set_log($log_file);
+set_debug($debug);
+printlog ("$runline");
+
+my $is_fastq = 0;
+my $srasize = 0;
 unless(-e $short_read_archive) {
-    pod2usage(-msg => "Must specify a short read archive in fasta or fastq form.");
+	# check to see if 1input and 2input were specified:
+	unless ((-e $short_read_1) && (-e $short_read_2)) {
+    	pod2usage(-msg => "Must specify a short read archive in fasta or fastq form.");
+	} else {
+		printlog "Two input files: $short_read_1 and $short_read_2\n";
+		if ($short_read_1 =~ /\.f.*q/) {
+			$is_fastq = 1;
+		}
+		$srasize = (-s $short_read_1);
+	}
+} else {
+	printlog "One input file: $short_read_archive\n";
+	if ($short_read_archive =~ /\.f.*q/) {
+		$is_fastq = 1;
+	}
+	$srasize = (-s $short_read_archive);
+}
+
+# if it's a fastq file, the file is twice the size that it would be if it were a fasta.
+if ($is_fastq) {
+	$srasize = $srasize/2;
 }
 
 unless ($output_file) {
@@ -58,21 +92,12 @@ unless (-d $output_path) {
 # Look in the config.txt file to find the correct paths to binaries.
 Configuration::initialize();
 
-if ($log_file eq "") {
-	$log_file = "$output_file.log";
-}
-
-set_log($log_file);
-set_debug($debug);
-printlog ("$runline");
-
 # making a redirect file to make it easier for users to have something to specify.
 my $db_file = "$output_file.atram";
 open DB_FH, ">", $db_file;
 print DB_FH "$output_file\n";
 close DB_FH;
 
-my $srasize = (-s $short_read_archive);
 my $srasizeMB = $srasize / 1e6;
 $srasizeMB =~ s/(\d*)\.(\d{2}).*/$1.$2/;
 
@@ -80,19 +105,15 @@ set_multiplier ($srasize);
 
 # if the user didn't specify how many shards to make, we should make as many as we need so that they average 250MB each.
 if ($numshards == 0) {
-	# if it's a fastq file, the file is twice the size that it would be if it were a fasta.
-	if ($short_read_archive =~ /\.f.*q/) {
-		$srasize = $srasize/2;
-	}
 	$numshards = int($srasize / 2.5e8);
 
 	# but if it's smaller than the minimum, make at least one shard.
 	if ($numshards == 0) {
 		$numshards = 1;
 	}
-	printlog ("$short_read_archive is $srasizeMB MB; we will make $numshards shards.");
+	printlog ("Input is $srasizeMB MB; we will make $numshards shards.");
 } else {
-	printlog ("making $numshards shards from $short_read_archive.");
+	printlog ("making $numshards shards.");
 }
 
 # declare how many shards we'll be making.
@@ -137,40 +158,77 @@ my $seq = "";
 my $seqlen = 0;
 my $shard = 0;
 
-open SEARCH_FH, "<:crlf", $short_read_archive;
-while (my $line = readline SEARCH_FH) {
-	chomp $line;
-	if ($line =~ /^[@>](.*?)([\s\/])([12])/) {
-		if ($name ne "") {
-			if ($name =~ /\/1/) {
-				print {$out1_fhs[$shard]} ">$name,$seq\n";
-			} elsif ($name =~ /\/2/) {
-				print {$out2_fhs[$shard]} ">$name,$seq\n";
+if ($short_read_archive ne "") {
+	open SEARCH_FH, "<:crlf", $short_read_archive;
+	while (my $line = readline SEARCH_FH) {
+		chomp $line;
+		if ($line =~ /^[@>](.*?)([\s\/])([12])/) {
+			if ($name ne "") {
+				if ($name =~ /\/1/) {
+					print {$out1_fhs[$shard]} ">$name,$seq\n";
+				} elsif ($name =~ /\/2/) {
+					print {$out2_fhs[$shard]} ">$name,$seq\n";
+				}
+			}
+			$name = "$1\/$3";
+			$shard = map_to_shard($name);
+			$keys[$shard]++;
+			$seq = "";
+		} elsif ($line =~ /^\+/){
+			# is this a fastq quality line? eat chars to the length of the full sequence.
+			while ($seqlen > 0) {
+				$line = readline SEARCH_FH;
+				chomp $line;
+				$seqlen = $seqlen - length($line);
+			}
+		} else {
+			$seq .= $line;
+			$seqlen = length ($seq);
+		}
+	}
+
+	if ($name =~ /\/1/) {
+		print {$out1_fhs[$shard]} ">$name,$seq\n";
+	} elsif ($name =~ /\/2/) {
+		print {$out2_fhs[$shard]} ">$name,$seq\n";
+	}
+	close SEARCH_FH;
+} else {
+	# there are two files: process the first and then the second.
+	my @sra_files = ($short_read_1, $short_read_2);
+	my @out_fhs = (\@out1_fhs, \@out2_fhs);
+	
+	for (my $i=0; $i<2; $i++) {
+		$name = "";
+		$seq = "";
+		open SEARCH_FH, "<:crlf", $sra_files[$i];
+		while (my $line = readline SEARCH_FH) {
+			chomp $line;
+			if ($line =~ /^[@>](.+?)(\/[12])*$/) {
+				if ($name ne "") {
+					print {@{$out_fhs[$i]}[$shard]} ">$name,$seq\n";
+				}
+				$name = "$1\/" . ($i+1);
+				$shard = map_to_shard($name);
+				$keys[$shard]++;
+				$seq = "";
+			} elsif ($line =~ /^\+/){
+				# is this a fastq quality line? eat chars to the length of the full sequence.
+				while ($seqlen > 0) {
+					$line = readline SEARCH_FH;
+					chomp $line;
+					$seqlen = $seqlen - length($line);
+				}
+			} else {
+				$seq .= $line;
+				$seqlen = length ($seq);
 			}
 		}
-		$name = "$1\/$3";
-		$shard = map_to_shard($name);
-		$keys[$shard]++;
-		$seq = "";
-	} elsif ($line =~ /^\+/){
-		# is this a fastq quality line? eat chars to the length of the full sequence.
-		while ($seqlen > 0) {
-			$line = readline SEARCH_FH;
-			chomp $line;
-			$seqlen = $seqlen - length($line);
-		}
-	} else {
-		$seq .= $line;
-		$seqlen = length ($seq);
-	}
+		print {@{$out_fhs[$i]}[$shard]} ">$name,$seq\n";
+		close SEARCH_FH;
+	}	
 }
 
-if ($name =~ /\/1/) {
-	print {$out1_fhs[$shard]} ">$name,$seq\n";
-} elsif ($name =~ /\/2/) {
-	print {$out2_fhs[$shard]} ">$name,$seq\n";
-}
-close SEARCH_FH;
 my @pids = ();
 printlog ("starting sort.");
 

--- a/format_sra.pl
+++ b/format_sra.pl
@@ -164,6 +164,10 @@ if ($short_read_archive ne "") {
 	open SEARCH_FH, "<:crlf", $short_read_archive;
 	while (my $line = readline SEARCH_FH) {
 		chomp $line;
+		### filetypes:
+		##  HWI-ST330:137:D057WACXX:7:1101:1222:2061 1:N:0:ACAGTG
+		##  HWI-ST330:137:D057WACXX:7:1101:1222:2061/1
+		##  HWI-ST330:137:D057WACXX:7:1101:1222:2061_1
 		if ($line =~ /^[@>](.*?)([\s\/_])([12])/) {
 			# new sequence, let's finish printing out the last sequence.
 			if ($name ne "") {
@@ -173,7 +177,6 @@ if ($short_read_archive ne "") {
 					print {$out2_fhs[$shard]} ">$name,$seq\n";
 				}
 			}
-			
 			# set up the name for the next sequence: we're going with "name/1" formatting
 			$name = "$1\/$3";
 			$shard = map_to_shard($name);
@@ -193,6 +196,7 @@ if ($short_read_archive ne "") {
 	}
 	if ($name =~ /1$/) {
 		print {$out1_fhs[$shard]} ">$name,$seq\n";
+	
 	} elsif ($name =~ /2$/) {
 		print {$out2_fhs[$shard]} ">$name,$seq\n";
 	}
@@ -208,7 +212,7 @@ if ($short_read_archive ne "") {
 		open SEARCH_FH, "<:crlf", $sra_files[$i];
 		while (my $line = readline SEARCH_FH) {
 			chomp $line;
-			if ($line =~ /^[@>](.+?)([\/_][12]).*$/) {
+			if ($line =~ /^[@>](.+?)([\s\/_][12]).*$/) {
 				if ($name ne "") {
 					print {@{$out_fhs[$i]}[$shard]} ">$name,$seq\n";
 				}

--- a/format_sra.pl
+++ b/format_sra.pl
@@ -60,7 +60,7 @@ unless(-e $short_read_archive) {
 		if ($short_read_1 =~ /\.f.*q/) {
 			$is_fastq = 1;
 		}
-		$srasize = (-s ($short_read_1 * 2));
+		$srasize = (-s ($short_read_1)) * 2;
 	}
 } else {
 	printlog "One input file: $short_read_archive\n";
@@ -102,6 +102,7 @@ my $srasizeMB = $srasize / 1e6;
 $srasizeMB =~ s/(\d*)\.(\d{2}).*/$1.$2/;
 
 set_multiplier ($srasize);
+printlog ("Multiplier is " . get_multiplier() . ".");
 
 # if the user didn't specify how many shards to make, we should make as many as we need so that they average 250MB each.
 if ($numshards == 0) {
@@ -113,7 +114,7 @@ if ($numshards == 0) {
 	}
 	printlog ("Input is $srasizeMB MB; we will make $numshards shards.");
 } else {
-	printlog ("making $numshards shards.");
+	printlog ("Making $numshards shards.");
 }
 
 # declare how many shards we'll be making.
@@ -159,22 +160,21 @@ my $seqlen = 0;
 my $shard = 0;
 
 if ($short_read_archive ne "") {
+	# there is one interleaved file.
 	open SEARCH_FH, "<:crlf", $short_read_archive;
 	while (my $line = readline SEARCH_FH) {
 		chomp $line;
-		### editing 7.17 need to capture it up here
-	#	if ($line =~ /^[@>](.*?)([\s\/])([12])/) {
 		if ($line =~ /^[@>](.*?)([\s\/_])([12])/) {
+			# new sequence, let's finish printing out the last sequence.
 			if ($name ne "") {
-				### editing 7.17. to allow different file types
-				#if ($name =~ /\/1/) {
-				if ($name =~ /(\/|_)1/) {
+				if ($name =~ /1$/) {
 					print {$out1_fhs[$shard]} ">$name,$seq\n";
-				#} elsif ($name =~ /\/2/) {
-				} elsif ($name =~ /(\/|_)2/) {
+				} elsif ($name =~ /2$/) {
 					print {$out2_fhs[$shard]} ">$name,$seq\n";
 				}
 			}
+			
+			# set up the name for the next sequence: we're going with "name/1" formatting
 			$name = "$1\/$3";
 			$shard = map_to_shard($name);
 			$keys[$shard]++;
@@ -191,12 +191,9 @@ if ($short_read_archive ne "") {
 			$seqlen = length ($seq);
 		}
 	}
-	### editing 7.17. to allow different file types
-	#if ($name =~ /\/1/) {
-	if ($name =~ /(\/|_)1/) {
+	if ($name =~ /1$/) {
 		print {$out1_fhs[$shard]} ">$name,$seq\n";
-	#} elsif ($name =~ /\/2/) {
-	} elsif ($name =~ /(\/|_)2/) {
+	} elsif ($name =~ /2$/) {
 		print {$out2_fhs[$shard]} ">$name,$seq\n";
 	}
 	close SEARCH_FH;
@@ -211,8 +208,6 @@ if ($short_read_archive ne "") {
 		open SEARCH_FH, "<:crlf", $sra_files[$i];
 		while (my $line = readline SEARCH_FH) {
 			chomp $line;
-			###  some fastq formats have _1 in the middle of the name others have /1 at the end. editing 7.17.15 
-#			if ($line =~ /^[@>](.+?)(\/[12]).*$/) {
 			if ($line =~ /^[@>](.+?)([\/_][12]).*$/) {
 				if ($name ne "") {
 					print {@{$out_fhs[$i]}[$shard]} ">$name,$seq\n";

--- a/format_sra.pl
+++ b/format_sra.pl
@@ -60,7 +60,7 @@ unless(-e $short_read_archive) {
 		if ($short_read_1 =~ /\.f.*q/) {
 			$is_fastq = 1;
 		}
-		$srasize = (-s $short_read_1);
+		$srasize = (-s ($short_read_1 * 2));
 	}
 } else {
 	printlog "One input file: $short_read_archive\n";
@@ -162,11 +162,16 @@ if ($short_read_archive ne "") {
 	open SEARCH_FH, "<:crlf", $short_read_archive;
 	while (my $line = readline SEARCH_FH) {
 		chomp $line;
-		if ($line =~ /^[@>](.*?)([\s\/])([12])/) {
+		### editing 7.17 need to capture it up here
+	#	if ($line =~ /^[@>](.*?)([\s\/])([12])/) {
+		if ($line =~ /^[@>](.*?)([\s\/_])([12])/) {
 			if ($name ne "") {
-				if ($name =~ /\/1/) {
+				### editing 7.17. to allow different file types
+				#if ($name =~ /\/1/) {
+				if ($name =~ /(\/|_)1/) {
 					print {$out1_fhs[$shard]} ">$name,$seq\n";
-				} elsif ($name =~ /\/2/) {
+				#} elsif ($name =~ /\/2/) {
+				} elsif ($name =~ /(\/|_)2/) {
 					print {$out2_fhs[$shard]} ">$name,$seq\n";
 				}
 			}
@@ -186,10 +191,12 @@ if ($short_read_archive ne "") {
 			$seqlen = length ($seq);
 		}
 	}
-
-	if ($name =~ /\/1/) {
+	### editing 7.17. to allow different file types
+	#if ($name =~ /\/1/) {
+	if ($name =~ /(\/|_)1/) {
 		print {$out1_fhs[$shard]} ">$name,$seq\n";
-	} elsif ($name =~ /\/2/) {
+	#} elsif ($name =~ /\/2/) {
+	} elsif ($name =~ /(\/|_)2/) {
 		print {$out2_fhs[$shard]} ">$name,$seq\n";
 	}
 	close SEARCH_FH;
@@ -204,7 +211,9 @@ if ($short_read_archive ne "") {
 		open SEARCH_FH, "<:crlf", $sra_files[$i];
 		while (my $line = readline SEARCH_FH) {
 			chomp $line;
-			if ($line =~ /^[@>](.+?)(\/[12])*$/) {
+			###  some fastq formats have _1 in the middle of the name others have /1 at the end. editing 7.17.15 
+#			if ($line =~ /^[@>](.+?)(\/[12]).*$/) {
+			if ($line =~ /^[@>](.+?)([\/_][12]).*$/) {
 				if ($name ne "") {
 					print {@{$out_fhs[$i]}[$shard]} ">$name,$seq\n";
 				}

--- a/lib/Assembler/Abyss.pm
+++ b/lib/Assembler/Abyss.pm
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+package Abyss;
+use strict;
+use System;
+use Parsing;
+use Configuration;
+
+my $binaries = {'abyss-pe' => "abyss-pe"};
+
+sub get_binaries {
+	return $binaries;
+}
+
+sub assembler {
+	my $self = shift;
+	my $short_read_file = shift;
+	my $params = shift;
+	
+	Configuration::initialize();
+	my ($kmer, $kmer2, $tempdir, $output_file) = 0;
+	if ((ref $params) =~ /HASH/) {
+	    if (exists $params->{"kmer"}) {
+		$kmer = $params->{"kmer"};
+	    }
+	    if (exists $params->{"tempdir"}) {
+		$tempdir = $params->{"tempdir"};
+	    }
+	    if (exists $params->{"output"}) {
+		$output_file = $params->{"output"};
+	    }
+	    if (exists $params->{"log_file"}) {
+		set_log($params->{"log_file"});
+	    }
+	}
+	# using ABySS
+	# truncate ABySS log file if it already exists
+	truncate "$tempdir/Log", 0;
+	## abyss single end
+	my $string="v=-v k=$kmer name=$short_read_file\_temp se='$short_read_file' E=0";
+	run_command (get_bin($binaries->{'abyss-pe'}), $string,1);
+	##single end abyss
+	my $str = "$short_read_file\_temp-unitigs.fa";
+	my ($contigs, undef) = parsefasta ($str);
+	### paired end abyss
+	# copy ABySS log output to logfile.
+	open LOGFH, "<:crlf", "$tempdir/Log";
+	printlog ("Abyss log:");
+	foreach my $line (<LOGFH>) {
+	    chomp $line;
+	    printlog ($line);
+	}
+	printlog ("end Abyss log");
+	close LOGFH;
+	open OUTFH, ">", $output_file;
+	foreach my $contigname (keys %$contigs) {
+	    my $sequence = $contigs->{$contigname};
+	    #aTRAM-test-contigs.fa
+#	    $contigname =~ s/^NODE_(\d+)_length_(\d+)_cov_(\d+\.\d).*$/$1_len_$2_cov_$3/;
+#	    $contigname =~ s/^(\S+)-contigs.fa/$1/;
+#	    $contigname =~ s/^>(.*)/$1/;
+	    print OUTFH ">$contigname\n$sequence\n";
+	}
+	###### remove temp files from abyss
+	`rm $short_read_file\_temp*`; 
+	###abyss paired end
+	close OUTFH;	
+	return $contigs;
+}
+return 1;
+

--- a/test/test_all.pl
+++ b/test/test_all.pl
@@ -43,8 +43,23 @@ printlog ("OK", ECHO);
 ##########################################################################################
 ## Testing format_sra.pl
 ##########################################################################################
-printlog (++$i .". Checking that format_sra works correctly...", ECHO);
+printlog (++$i .". Checking that format_sra works correctly on an interleaved file...", ECHO);
 $result = run_command ("$executing_path/../format_sra.pl", "-in $executing_path/test_sra.fasta -out $temp_dir/test_db -num 7 $debug_flag $log_flag", {"no_exit"=>1});
+if ($result != 0) {
+	fail_with_msg ("Format_sra failed.");
+}
+
+`tail -n +2 $temp_dir/test_db.atram > $temp_dir/test_db.test`;
+`diff $executing_path/test_format.txt $temp_dir/test_db.test > $executing_path/test.results.$i.diff`;
+if ($? != 0) {
+	fail_with_msg ("Format_sra returned incorrect results.");
+}
+`rm $executing_path/test.results.$i.diff`;
+
+printlog ("OK", ECHO);
+
+printlog (++$i .". Checking that format_sra works correctly on two separate files...", ECHO);
+$result = run_command ("$executing_path/../format_sra.pl", "-1input $executing_path/test_sra1.fasta -2input $executing_path/test_sra2.fasta -out $temp_dir/test_db -num 7 $debug_flag $log_flag", {"no_exit"=>1});
 if ($result != 0) {
 	fail_with_msg ("Format_sra failed.");
 }


### PR DESCRIPTION
on line 63 fixed an error in calculating file size when there are two
input files. This was affecting the number of shards the program would
produce if the same file was given as two input or one input file.

The second fix is allowing format_sra to be able to read input files
that have an _1 in the name rather than a /1 at the end of the name.
This has been checked for both 1 input file as well as for two
different input files.