### PR TITLE
Fix file name in test

### DIFF
--- a/tests/test_atram_preprocessor.py
+++ b/tests/test_atram_preprocessor.py
@@ -204,7 +204,7 @@ class TestAtramPreprocessor(unittest.TestCase):
 
         atram_preprocessor.create_one_blast_shard(self.args, shard_params, 11)
 
-        path = join(self.args['temp_dir'], 'pyt_011.fasta')
+        path = join(self.args['temp_dir'], 'pytest_011.fasta')
 
         fill_blast_fasta.assert_called_once_with(
             self.args['blast_db'], path, shard_params)


### PR DESCRIPTION
The file name doesn't match the actual file's name, so it causes the test to fail.